### PR TITLE
Minor update of error handling

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,23 @@
+# EditorConfig: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+
+# Various options
+trim_trailing_whitespace = true
+
+[*.{c,h}]
+# 4 space indentation
+#tab_width = 4
+indent_style = space
+indent_size = 4
+
+[Makefile]
+indent_style = tab
+tab_width = 4

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+*.o
+mpi_file_set_view
+mpi_file_open
+print_mpi_io_hints
+mpi_tag_ub
+mpi_create_delete_loop
+testfile

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,6 @@ mpi_file_open
 print_mpi_io_hints
 mpi_tag_ub
 mpi_create_delete_loop
+fileview_subarray
+ghost_cell
 testfile

--- a/Makefile
+++ b/Makefile
@@ -20,4 +20,3 @@ clean:
 	rm -f core.* *.o testfile.out $(check_PROGRAMS)
 
 .PHONY: clean
-

--- a/mpi_file_open.c
+++ b/mpi_file_open.c
@@ -11,14 +11,7 @@
 
 #define LEN 10
 
-#define CHECK_ERR(func) { \
-    if (err != MPI_SUCCESS) { \
-        int errorStringLen; \
-        char errorString[MPI_MAX_ERROR_STRING]; \
-        MPI_Error_string(err, errorString, &errorStringLen); \
-        printf("Error at line %d: calling %s (%s)\n",__LINE__, #func, errorString); \
-    } \
-}
+#include "mpi_utils.h"
 
 /*----< main() >------------------------------------------------------------*/
 int main(int argc, char **argv)
@@ -29,10 +22,8 @@ int main(int argc, char **argv)
     MPI_Info info;
 
     MPI_Init(&argc, &argv);
-    err = MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-    CHECK_ERR(MPI_Comm_rank);
-    err = MPI_Comm_size(MPI_COMM_WORLD, &nprocs);
-    CHECK_ERR(MPI_Comm_size);
+    MPI_CHECK_ERR( MPI_Comm_rank(MPI_COMM_WORLD, &rank) );
+    MPI_CHECK_ERR( MPI_Comm_size(MPI_COMM_WORLD, &nprocs) );
 
     filename = "testfile.out";
     if (argc > 1) filename = argv[1];
@@ -45,23 +36,19 @@ int main(int argc, char **argv)
     cmode |= MPI_MODE_WRONLY; /* with write-only permission */
 
     /* collectively open a file, shared by all processes in MPI_COMM_WORLD */
-    err = MPI_File_open(MPI_COMM_WORLD, filename, cmode, info, &fh);
-    CHECK_ERR(MPI_File_open to write);
+    MPI_CHECK_ERR( MPI_File_open(MPI_COMM_WORLD, filename, cmode, info, &fh) );
 
     /* collectively close the file */
-    err = MPI_File_close(&fh);
-    CHECK_ERR(MPI_File_close);
+    MPI_CHECK_ERR( MPI_File_close(&fh) );
 
     /* set file open mode */
     omode = MPI_MODE_RDONLY; /* with read-only permission */
 
     /* collectively open a file, shared by all processes in MPI_COMM_WORLD */
-    err = MPI_File_open(MPI_COMM_WORLD, filename, omode, info, &fh);
-    CHECK_ERR(MPI_File_open to read);
+    MPI_CHECK_ERR( MPI_File_open(MPI_COMM_WORLD, filename, omode, info, &fh) );
 
     /* collectively close the file */
-    err = MPI_File_close(&fh);
-    CHECK_ERR(MPI_File_close);
+    MPI_CHECK_ERR( MPI_File_close(&fh) );
 
 prog_exit:
     MPI_Finalize();

--- a/mpi_tag_ub.c
+++ b/mpi_tag_ub.c
@@ -12,14 +12,7 @@
 #include <stdlib.h>
 #include <mpi.h>
 
-#define CHECK_ERR(func) { \
-    if (err != MPI_SUCCESS) { \
-        int errorStringLen; \
-        char errorString[MPI_MAX_ERROR_STRING]; \
-        MPI_Error_string(err, errorString, &errorStringLen); \
-        printf("Error at line %d: calling %s (%s)\n",__LINE__, #func, errorString); \
-    } \
-}
+#include "mpi_utils.h"
 
 int main(int argc, char **argv)
 {
@@ -27,11 +20,10 @@ int main(int argc, char **argv)
     int err, rank, tag_ub, isSet;
 
     MPI_Init(&argc,&argv);
-    err = MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-    CHECK_ERR(MPI_Comm_rank);
 
-    err = MPI_Comm_get_attr(MPI_COMM_WORLD, MPI_TAG_UB, &value, &isSet);
-    CHECK_ERR(MPI_Comm_get_attr);
+    MPI_CHECK_ERR( MPI_Comm_rank(MPI_COMM_WORLD, &rank) );
+
+    MPI_CHECK_ERR( MPI_Comm_get_attr(MPI_COMM_WORLD, MPI_TAG_UB, &value, &isSet) );
 
     tag_ub = *(int *) value;
     if (isSet)
@@ -40,6 +32,5 @@ int main(int argc, char **argv)
         printf("rank %d: attribute MPI_TAG_UB for MPI_COMM_WORLD is NOT set\n",rank);
 
     MPI_Finalize();
-    return 0; 
+    return 0;
 }
-

--- a/mpi_utils.h
+++ b/mpi_utils.h
@@ -2,6 +2,7 @@
 #define MPI_UTILS_H_
 
 #include <mpi.h>
+#include <stdio.h>
 
 int mpi_check_error(int err,
                     char const *const func,
@@ -14,7 +15,7 @@ int mpi_check_error(int err,
         int errorStringLen;
         char errorString[MPI_MAX_ERROR_STRING];
         MPI_Error_string(err, errorString, &errorStringLen);
-        fprintf(stderr, "Error at line %d: calling %s (%s)\n",line, func, errorString);
+        fprintf(stderr, "Error at %s:%d: calling %s ==> %s\n",file, line, func, errorString);
     }
 
     return err;

--- a/mpi_utils.h
+++ b/mpi_utils.h
@@ -1,0 +1,25 @@
+#ifndef MPI_UTILS_H_
+#define MPI_UTILS_H_
+
+#include <mpi.h>
+
+int mpi_check_error(int err,
+                    char const *const func,
+                    const char *const file,
+                    int const line)
+{
+
+    if (err != MPI_SUCCESS)
+    {
+        int errorStringLen;
+        char errorString[MPI_MAX_ERROR_STRING];
+        MPI_Error_string(err, errorString, &errorStringLen);
+        fprintf(stderr, "Error at line %d: calling %s (%s)\n",line, func, errorString);
+    }
+
+    return err;
+} // check_mpi_error
+
+#define MPI_CHECK_ERR(value) mpi_check_error((value), #value, __FILE__, __LINE__)
+
+#endif // MPI_UTILS_H_

--- a/tests/mpi_create_delete_loop.c
+++ b/tests/mpi_create_delete_loop.c
@@ -1,44 +1,35 @@
+#include <errno.h> /* errno */
+#include <mpi.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <errno.h>  /* errno */
 #include <string.h> /* memset(), strerror() */
 #include <unistd.h> /* unlink() */
-#include <mpi.h>
 
 #define MAX_TRIES 100000
 
-#define CHECK_ERR(func) { \
-    if (err != MPI_SUCCESS) { \
-        int errorStringLen; \
-        char errorString[MPI_MAX_ERROR_STRING]; \
-        MPI_Error_string(err, errorString, &errorStringLen); \
-        if (rank == 0) \
-            printf("Error at line %d: calling %s (%s)\n",__LINE__, #func, errorString); \
-    } \
-}
+#include "mpi_utils.h"
 
-int main(int argc, char** argv) {
+int main(int argc, char **argv) {
+
     char *filename, buf[512];
     int i, rank, nprocs, err, sys_err;
     MPI_Status status;
     MPI_File fh;
 
     MPI_Init(&argc, &argv);
-    err = MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-    CHECK_ERR(MPI_Comm_rank);
-    err = MPI_Comm_size(MPI_COMM_WORLD, &nprocs);
-    CHECK_ERR(MPI_Comm_size);
+    MPI_CHECK_ERR(MPI_Comm_rank(MPI_COMM_WORLD, &rank));
+    MPI_CHECK_ERR(MPI_Comm_size(MPI_COMM_WORLD, &nprocs));
 
     filename = "testfile";
     memset(buf, 0, 512);
 
-    for (i=0; i<MAX_TRIES; i++) {
+    for (i = 0; i < MAX_TRIES; i++) {
 
         /* mimic NC_CLOBBER */
         if (rank == 0) {
             err = unlink(filename);
             if (err < 0 && errno != ENOENT) { /* ignore ENOENT: file not exist */
-                printf("Error: unlink() errno=%d (%s)\n",errno,strerror(errno));
+                printf("Error: unlink() errno=%d (%s)\n", errno, strerror(errno));
                 sys_err = -1;
             }
             else
@@ -46,26 +37,32 @@ int main(int argc, char** argv) {
         }
 
         /* all processes must wait here until file deletion is completed */
-        err = MPI_Bcast(&sys_err, 1, MPI_INT, 0, MPI_COMM_WORLD);
-        CHECK_ERR(MPI_Bcast);
-        if (err != MPI_SUCCESS) break; /* loop i */
+        err = MPI_CHECK_ERR(MPI_Bcast(&sys_err, 1, MPI_INT, 0, MPI_COMM_WORLD));
 
-        if (sys_err != 0) break; /* loop i */
+        if (err != MPI_SUCCESS)
+            break; /* loop i */
+
+        if (sys_err != 0)
+            break; /* loop i */
 
         /* all processes open the file in parallel */
-        err = MPI_File_open(MPI_COMM_WORLD, filename, MPI_MODE_CREATE | MPI_MODE_RDWR, MPI_INFO_NULL, &fh);
-        CHECK_ERR(MPI_File_open);
-        if (err != MPI_SUCCESS) break; /* loop i */
+        err = MPI_CHECK_ERR(MPI_File_open(MPI_COMM_WORLD, filename,
+                                          MPI_MODE_CREATE | MPI_MODE_RDWR,
+                                          MPI_INFO_NULL, &fh));
+
+        if (err != MPI_SUCCESS)
+            break; /* loop i */
 
         if (rank == 0) { /* mimic PnetCDF rank 0 writes to file header */
-            err = MPI_File_write(fh, buf, 512, MPI_BYTE, &status);
-            CHECK_ERR(MPI_File_write);
-            if (err != MPI_SUCCESS) break; /* loop i */
+            err = MPI_CHECK_ERR(MPI_File_write(fh, buf, 512, MPI_BYTE, &status));
+
+            if (err != MPI_SUCCESS)
+                break; /* loop i */
         }
 
-        err = MPI_File_close(&fh);
-        CHECK_ERR(MPI_File_close);
-        if (err != MPI_SUCCESS) break; /* loop i */
+        err = MPI_CHECK_ERR(MPI_File_close(&fh));
+        if (err != MPI_SUCCESS)
+            break; /* loop i */
     }
 
     MPI_Finalize();


### PR DESCRIPTION
I would like to suggest a minor change in the way error are handled, e.g. change

```c
err = MPI_Comm_rank(MPI_COMM_WORLD, &rank);
CHECK_ERR(MPI_Comm_rank);
```
into
```c
MPI_CHECK_ERR( MPI_Comm_rank(MPI_COMM_WORLD, &rank) );
```

so that, you don't need to repeat the name of the API to check.
There were a couple of places where they didn't match (in `mpi_file_set_view.c`)

other minor change: the error preprocessor macro is moved into a separate header file.
